### PR TITLE
fix accParent

### DIFF
--- a/msaa.py
+++ b/msaa.py
@@ -186,7 +186,9 @@ class Element(object):
 
     def accParent(self):
         '''Get Element Parent'''
-        return self.IAccessible.accParent()
+        objParent = self.IAccessible.accParent
+        if objParent is not None:
+            return Element(self.IAccessible.accParent, 0)
 
     def accSelection(self):
         '''Get Element Selection Status'''


### PR DESCRIPTION
Calling `accParent()` always returned `TypeError: 'POINTER(IAccessible)' object is not callable`